### PR TITLE
Add EC2 instance resource to Terraform configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -103,15 +103,16 @@ resource "aws_security_group" "web" {
   }
 }
 
-# EC2 instance will be added here by the AI agent
-# Example:
-# resource "aws_instance" "web" {
-#   ami           = "ami-0c55b159cbfafe1f0"
-#   instance_type = "t2.micro"
-#   subnet_id     = aws_subnet.public.id
-#   security_groups = [aws_security_group.web.id]
-#   
-#   tags = {
-#     Name = "web-server"
-#   }
-# }
+# EC2 instance resource
+resource "aws_instance" "web" {
+  ami           = var.ami_id
+  instance_type = var.instance_type
+  subnet_id     = aws_subnet.public.id
+  vpc_security_group_ids = [aws_security_group.web.id]
+
+  associate_public_ip_address = true
+
+  tags = {
+    Name = "web-server"
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,13 +13,12 @@ output "security_group_id" {
   value       = aws_security_group.web.id
 }
 
-# Future outputs for the EC2 instance
-# output "instance_id" {
-#   description = "ID of the EC2 instance"
-#   value       = aws_instance.web.id
-# }
-#
-# output "public_ip" {
-#   description = "Public IP of the EC2 instance"
-#   value       = aws_instance.web.public_ip
-# }
+output "instance_id" {
+  description = "ID of the EC2 instance"
+  value       = aws_instance.web.id
+}
+
+output "public_ip" {
+  description = "Public IP of the EC2 instance"
+  value       = aws_instance.web.public_ip
+}

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,6 @@ variable "subnet_cidr" {
   default     = "10.0.1.0/24"
 }
 
-# Variables that would be needed for the EC2 instance
 variable "ami_id" {
   description = "AMI ID for the EC2 instance"
   type        = string


### PR DESCRIPTION
- Use variables for AMI ID and instance type
- Associate instance with existing VPC, public subnet, and security group
- Ensure public IP is associated
- Add outputs for instance ID and public IP