### PR TITLE
Update default AMI ID in variables.tf

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,7 @@ variable "subnet_cidr" {
 variable "ami_id" {
   description = "AMI ID for the EC2 instance"
   type        = string
-  default     = "ami-0c55b159cbfafe1f0" # Example Amazon Linux 2 AMI
+  default     = "ami-0b0ea68c435eb488d" # Updated AMI ID
 }
 
 variable "instance_type" {


### PR DESCRIPTION
This PR updates the default value of the variable `ami_id` in variables.tf to use the AMI ID `ami-0b0ea68c435eb488d` for the EC2 configuration.